### PR TITLE
Use base SHA instead of base branch since the base branch

### DIFF
--- a/.github/workflows/aviator-targets.yml
+++ b/.github/workflows/aviator-targets.yml
@@ -16,11 +16,21 @@ jobs:
           node-version: '18'
           cache: 'yarn'
       - run: yarn install
+      - uses: octokit/request-action@v2.x
+        id: get_pr
+        with:
+          route: GET /repos/${{ github.repository }}/pulls/${{ github.event.number }}
+          owner: octokit
+          repo: request-action
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - run: "echo latest sha: '${{ fromJson(steps.get_pr.outputs.data).base.sha }}'"
       - run: |
           set -euo pipefail
           git fetch origin $GITHUB_BASE_REF
           PR_NUMBER=${{ github.event.number }}
-          TARGETS_JSON=$(npx nx show projects --affected --base FETCH_HEAD --head HEAD --json)
+          TARGETS_JSON=$(npx nx show projects --affected --base FETCH_HEAD --head ${{ github.sha }} --json)
           echo $TARGETS_JSON
           curl -X POST -H "Authorization: Bearer ${{ secrets.AVIATOR_API_TOKEN }}" \
           -H "Content-Type: application/json" \

--- a/.github/workflows/aviator-targets.yml
+++ b/.github/workflows/aviator-targets.yml
@@ -4,13 +4,16 @@ on:
   pull_request:
 
 jobs:
-  nextjs-build:
+  fetch-aviator-targets:
     runs-on: ubuntu-latest
     defaults:
       run:
          working-directory: .
     steps:
       - uses: actions/checkout@v4
+        with:
+          filter: 'blob:none'
+          depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18'
@@ -27,7 +30,6 @@ jobs:
 
       - run: |
           set -euo pipefail
-          git fetch origin $GITHUB_BASE_REF
           PR_NUMBER=${{ github.event.number }}
           TARGETS_JSON=$(npx nx show projects --affected --base ${{ fromJson(steps.get_pr.outputs.data).base.sha }} --head ${{ github.sha }} --json)
           echo $TARGETS_JSON

--- a/.github/workflows/aviator-targets.yml
+++ b/.github/workflows/aviator-targets.yml
@@ -11,9 +11,6 @@ jobs:
          working-directory: .
     steps:
       - uses: actions/checkout@v4
-        with:
-          filter: 'blob:none'
-          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18'

--- a/.github/workflows/aviator-targets.yml
+++ b/.github/workflows/aviator-targets.yml
@@ -11,6 +11,11 @@ jobs:
          working-directory: .
     steps:
       - uses: actions/checkout@v4
+        with:
+          # using partial clone to make sure we fetch what we need
+          # when comparing base and head.
+          filter: 'blob:none'
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18'

--- a/.github/workflows/aviator-targets.yml
+++ b/.github/workflows/aviator-targets.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           filter: 'blob:none'
-          depth: 0
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: '18'

--- a/.github/workflows/aviator-targets.yml
+++ b/.github/workflows/aviator-targets.yml
@@ -25,13 +25,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - run: "echo latest sha: '${{ fromJson(steps.get_pr.outputs.data).base.sha }}'"
       - run: |
           set -euo pipefail
           git fetch origin $GITHUB_BASE_REF
           PR_NUMBER=${{ github.event.number }}
-          TARGETS_JSON=$(npx nx show projects --affected --base FETCH_HEAD --head ${{ github.sha }} --json)
+          TARGETS_JSON=$(npx nx show projects --affected --base ${{ fromJson(steps.get_pr.outputs.data).base.sha }} --head ${{ github.sha }} --json)
           echo $TARGETS_JSON
+          echo latest sha: '${{ fromJson(steps.get_pr.outputs.data).base.sha }}'
           curl -X POST -H "Authorization: Bearer ${{ secrets.AVIATOR_API_TOKEN }}" \
           -H "Content-Type: application/json" \
           -d '{

--- a/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
+++ b/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import '@nx-example/shared/product/ui';
 
-
 import {
   CartItem,
   cartReducer,

--- a/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
+++ b/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
@@ -1,5 +1,4 @@
 import { useReducer } from 'react';
-
 import styled from '@emotion/styled';
 
 import '@nx-example/shared/product/ui';

--- a/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
+++ b/libs/cart/cart-page/src/lib/cart-cart-page/cart-cart-page.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import '@nx-example/shared/product/ui';
 
+
 import {
   CartItem,
   cartReducer,


### PR DESCRIPTION
A PR could be using a stale base SHA. When calculating the affected targets, we should use the diff from base SHA to the head SHA. Since GH does not provide base SHA directly in the workflow action, make an API call to get the results.